### PR TITLE
fix: hydration error

### DIFF
--- a/src/components/sidebars/AppMenuItem.tsx
+++ b/src/components/sidebars/AppMenuItem.tsx
@@ -30,7 +30,7 @@ export function AppMenuItem({
   }
 
   return (
-    <Link {...link} passHref>
+    <Link {...link} passHref legacyBehavior>
       <ListItem
         button
         component="a"


### PR DESCRIPTION
Because `Link` and  `ListItem` component render an `<a>` tag, which is causing an `<a>` inside `<a>` tag, we should add `legacyBehavior` props to the `Link` component, so it will assume that the child will render an `<a>` tag.

Reference:
- https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-tag
- https://stackoverflow.com/questions/71706064/react-18-hydration-failed-because-the-initial-ui-does-not-match-what-was-render/71870995#71870995

Fix #82